### PR TITLE
feat: parameterize GitHub owner for sync scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Metarepo dient als zentraler, lernender Meta-Layer. Es spiegelt **kanonische Tem
 ## Tooling
 - `scripts/sync-templates.sh` — bidirektional (pull/push), Filter über `--pattern`.
 - `scripts/wgx-doctor` — Drift-Meter + Reconciliation Report (Markdown unter `reports/`).
+- **Owner-Parameter**: `GITHUB_OWNER` oder `--owner` setzen, z. B. `export GITHUB_OWNER=org && ./scripts/wgx-doctor --repo X --owner-from-env` bzw. `./scripts/sync-templates.sh --push-to X --owner org`.
 
 ## Sicherheitsmodus
 - Kein Commit ohne Diff-Vorschau.

--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -24,6 +24,8 @@ USG
 REPO_FROM=""; REPO_TO=""
 REPOS_FROM_FILE=""
 PATTERNS=()
+OWNER="${GITHUB_OWNER:-alexdermohr}"
+CUSTOM_OWNER_SET=0
 DRYRUN=0
 
 while [[ $# -gt 0 ]]; do
@@ -32,6 +34,8 @@ while [[ $# -gt 0 ]]; do
     --push-to)   REPO_TO="$2"; shift 2 ;;
     --repos-from) REPOS_FROM_FILE="$2"; shift 2 ;;
     --pattern)   PATTERNS+=("$2"); shift 2 ;;
+    --owner)     OWNER="$2"; CUSTOM_OWNER_SET=1; shift 2 ;;
+    --owner-from-env) OWNER="${GITHUB_OWNER:?Missing GITHUB_OWNER}"; CUSTOM_OWNER_SET=1; shift ;;
     --dry-run)   DRYRUN=1; shift ;;
     -h|--help)   usage; exit 0 ;;
     *) yellow "Ignoriere unbekanntes Argument: $1"; shift ;;
@@ -55,7 +59,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 clone_repo(){
   local name="$1"
-  local url="https://github.com/alexdermohr/${name}.git"
+  local url="https://github.com/${OWNER}/${name}.git"
   rm -rf "$TMPDIR/$name"
   git -c advice.detachedHead=false clone --depth=1 "$url" "$TMPDIR/$name" >/dev/null 2>&1 || {
     red "Clone fehlgeschlagen: $url"; exit 1; }

--- a/scripts/wgx-doctor
+++ b/scripts/wgx-doctor
@@ -5,11 +5,15 @@ usage(){ echo "Usage: $0 --repo <name> [--patterns \"glob1,glob2\"]"; }
 
 REPO=""
 PATTERNS="templates/.github/workflows/*.yml,templates/Justfile,templates/docs/**,templates/.wgx/profile.yml"
+OWNER="${GITHUB_OWNER:-alexdermohr}"
+CUSTOM_OWNER_SET=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo) REPO="$2"; shift 2 ;;
     --patterns) PATTERNS="$2"; shift 2 ;;
+    --owner) OWNER="$2"; CUSTOM_OWNER_SET=1; shift 2 ;;
+    --owner-from-env) OWNER="${GITHUB_OWNER:?Missing GITHUB_OWNER}"; CUSTOM_OWNER_SET=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) shift ;;
   esac
@@ -20,7 +24,7 @@ TS="$(date +%Y%m%d-%H%M%S)"
 TMPDIR="$(mktemp -d)"; trap 'rm -rf "$TMPDIR"' EXIT
 REPORT="reports/drift-${REPO}-${TS}.md"; mkdir -p reports
 
-git clone --depth=1 "https://github.com/alexdermohr/${REPO}.git" "$TMPDIR/$REPO" >/dev/null 2>&1 || {
+git clone --depth=1 "https://github.com/${OWNER}/${REPO}.git" "$TMPDIR/$REPO" >/dev/null 2>&1 || {
   echo "Clone fehlgeschlagen: $REPO"; exit 1; }
 
 echo "# Drift Report: $REPO ($TS)" > "$REPORT"


### PR DESCRIPTION
## Summary
- allow scripts/sync-templates.sh to accept a configurable GitHub owner via flag or environment variable
- extend scripts/wgx-doctor with the same owner customization and reuse the value when cloning repositories
- document the new owner parameter usage within AGENTS.md so other namespaces know how to configure it

## Testing
- `chmod +x scripts/sync-templates.sh scripts/wgx-doctor`
- `./scripts/sync-templates.sh --help >/dev/null || true`
- `./scripts/wgx-doctor -h >/dev/null || true`
- `export GITHUB_OWNER="alexdermohr"`
- `./scripts/wgx-doctor --repo weltgewebe --owner-from-env || true`
- `./scripts/sync-templates.sh --pull-from hauski-audio --owner alexdermohr --pattern "templates/docs/**" --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68e166d1d428832c915f4d06c434f8a5