### PR TITLE
fix: restore schema check block indentation

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Run schema-lite check
         run: |
           python - <<'PY'
-          import sys, yaml, pathlib
+          import sys
+          import yaml
+          import pathlib
 
           p = pathlib.Path(".wgx/profile.yml")
           data = yaml.safe_load(p.read_text(encoding="utf-8"))

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -31,38 +31,38 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
       - name: Install PyYAML for schema check
         run: |
           python -m pip install --upgrade pip
           python -m pip install "pyyaml~=6.0"
+
       - name: Run schema-lite check
-        shell: python
         run: |
-          import pathlib
-          import sys
+          python - <<'PY'
+          import sys, yaml, pathlib
 
-          import yaml
-
-          profile_path = pathlib.Path(".wgx/profile.yml")
-          data = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+          p = pathlib.Path(".wgx/profile.yml")
+          data = yaml.safe_load(p.read_text(encoding="utf-8"))
 
           required_top = ["version", "env_priority", "tooling", "tasks"]
-          missing = [key for key in required_top if key not in data]
+          missing = [k for k in required_top if k not in data]
           if missing:
               print(f"::error::missing keys: {missing}")
               sys.exit(1)
 
-          env_priority = data["env_priority"]
-          if not isinstance(env_priority, list) or not env_priority:
+          envp = data["env_priority"]
+          if not isinstance(envp, list) or not envp:
               print("::error::env_priority must be a non-empty list")
               sys.exit(1)
 
-          for task_name in ["up", "lint", "test", "build", "smoke"]:
-              if task_name not in data["tasks"]:
-                  print(f"::error::task '{task_name}' missing")
+          for t in ["up", "lint", "test", "build", "smoke"]:
+              if t not in data["tasks"]:
+                  print(f"::error::task '{t}' missing")
                   sys.exit(1)
 
           print("schema-lite ok")
+          PY
 
       - name: (Optional) UV bootstrap (pyproject present)
         if: ${{ hashFiles('pyproject.toml') != '' }}


### PR DESCRIPTION
## Summary
- add spacing between workflow steps for readability
- run the schema-lite validation via a heredoc python snippet with restored indentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a088a31c832c9e6f6961dce9300e