### PR TITLE
Refine shellcheck workflow and sync PR copy

### DIFF
--- a/.github/workflows/ci-shellcheck.yml
+++ b/.github/workflows/ci-shellcheck.yml
@@ -1,0 +1,35 @@
+name: ci-shellcheck
+
+on:
+  push:
+    paths:
+      - '**/*.sh'
+      - '.github/workflows/ci-shellcheck.yml'
+  pull_request:
+    paths:
+      - '**/*.sh'
+      - '.github/workflows/ci-shellcheck.yml'
+  workflow_dispatch:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: sudo apt-get update -yqq && sudo apt-get install -yqq shellcheck
+
+      - name: Run ShellCheck on tracked scripts
+        run: |
+          set -euo pipefail
+
+          mapfile -t scripts < <(git ls-files '*.sh')
+
+          if [ "${#scripts[@]}" -eq 0 ]; then
+            echo "No shell scripts found."
+            exit 0
+          fi
+
+          shellcheck "${scripts[@]}"

--- a/scripts/wgx
+++ b/scripts/wgx
@@ -52,17 +52,18 @@ copy_templates_into_repo() {
   rsync -a "$tmp/." "$workdir/"
 
   pushd "$workdir" >/dev/null
-    git checkout -b chore/wgx-sync-$(date +%Y%m%d-%H%M%S) || true
+    local branch="chore/wgx-sync-$(date +%Y%m%d-%H%M%S)"
+    git checkout -b "$branch" || true
     git add -A
     if ! git diff --cached --quiet; then
       git commit -m "chore(wgx): sync templates from metarepo"
       git push -u origin HEAD
-      gh pr create --title "chore(wgx): sync templates" --body "Sync from metarepo templates" || true
+      gh pr create --title "chore(wgx): sync templates" --body "Automated sync from metarepo on branch \`$branch\`" || true
     else
       echo "No changes for $r"
     fi
   popd >/dev/null
-  rm -rf "$tmp" "$workdir"
+  rm -rf "${tmp:?}" "${workdir:?}"
 }
 
 cmd_up() {


### PR DESCRIPTION
## Summary
- ensure the ci-shellcheck workflow installs ShellCheck quietly before running
- include the generated branch name in the automated sync PR body for transparency

## Testing
- `chmod +x scripts/wgx`
- `./scripts/wgx list || true`
- `if command -v shellcheck >/dev/null; then git ls-files '*.sh' | xargs -r shellcheck; fi`


------
https://chatgpt.com/codex/tasks/task_e_68e166438e6c832c993ace1b7910de60