### PR TITLE
Fix sync script glob handling for shellcheck

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -80,7 +80,15 @@ copy_into_metarepo_from_repo(){
       templates/*) src="${p#templates/}" ;;
       *) src="$p" ;;
     esac
-    files=( "$TMPDIR/$name"/${src} )
+    local pattern
+    pattern="$TMPDIR/$name/$src"
+    local -a files=()
+    while IFS= read -r -d '' match; do
+      files+=("$match")
+    done < <(find "$TMPDIR/$name" -path "$pattern" -print0 2>/dev/null)
+    if [[ ${#files[@]} -eq 0 ]]; then
+      continue
+    fi
     for f in "${files[@]}"; do
       # Remove TMPDIR/$name/ prefix for destination path
       rel_f="${f#$TMPDIR/$name/}"


### PR DESCRIPTION
## Summary
- collect template matches with find/print0 to avoid unsafe array expansion warnings in sync-templates.sh

## Testing
- bash -n scripts/sync-templates.sh
- bash -n scripts/ci-helpers.sh

------
https://chatgpt.com/codex/tasks/task_e_68e1a9050b14832c80e7a4d329a5a477