### PR TITLE
fix(sync-templates): correct parameter expansion quoting

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -95,7 +95,7 @@ copy_into_metarepo_from_repo(){
 
     for f in "${files[@]}"; do
       # Remove TMPDIR/$name/ prefix for destination path
-      rel_f="${f#$TMPDIR/$name/}"
+      rel_f="${f#${TMPDIR}/${name}/}"
       [[ -z "$rel_f" || "$rel_f" == "$f" ]] && continue
       dest="$PWD/templates/$rel_f"
       if ((DRYRUN==1)); then


### PR DESCRIPTION
## Summary
- fix the relative path parameter expansion in `sync-templates.sh` to satisfy ShellCheck SC2295 quoting requirements

## Testing
- not run (tooling unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68e2070d3ec8832cb775b1d3c7394071