### PR TITLE
fix: properly quote TMPDIR expansion in sync script

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -95,7 +95,7 @@ copy_into_metarepo_from_repo(){
 
     for f in "${files[@]}"; do
       # Remove TMPDIR/$name/ prefix for destination path
-      rel_f="${f#$TMPDIR/$name/}"
+      rel_f="${f#${TMPDIR}/${name}/}"
       [[ -z "$rel_f" || "$rel_f" == "$f" ]] && continue
       dest="$PWD/templates/$rel_f"
       if ((DRYRUN==1)); then


### PR DESCRIPTION
## Summary
- quote the TMPDIR/name prefix removal in the template sync script to satisfy ShellCheck

## Testing
- not run (shellcheck not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e20712b0fc832cb349f4c6abf1c8a7