### PR TITLE
docs: add link check workflow and stub update

### DIFF
--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -1,0 +1,16 @@
+name: docs-linkcheck
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install lychee
+        run: cargo install lychee
+      - name: Check documentation links
+        run: lychee --no-progress --exclude-mail --timeout 10s docs/**/*.md

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install lychee
-        run: cargo install lychee
+      - name: Set up lychee
+        uses: lycheeverse/lychee-action@v1
       - name: Check documentation links
         run: lychee --no-progress --exclude-mail --timeout 10s docs/**/*.md

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # metarepo
 
+**Docs:** siehe [docs/README.md](docs/README.md) · WGX-Master-Doku: https://github.com/alexdermohr/wgx
+
 Zentrale Steuerzentrale (Meta-Layer) für alle Repos von **alexdermohr**.
 Enthält:
 - **WGX-Master**: Referenzdoku + `.wgx/profile.yml`-Template

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# metarepo · Docs-Index (Tower)
+Diese Dokumente beschreiben **Fleet/Themen** des metarepo (Inventar, Verteilung, CI-Reusables, Drift).
+Für **WGX (Engine)** siehe: https://github.com/alexdermohr/wgx
+
+## Inhalte
+- [Fleet-Operations](./fleet.md)
+- [repos.yml – Inventar & Filter](./repos.yml.md)
+- [Templates verteilen & driftfrei halten](./templates.md)
+- [CI-Reusables](./ci-reusables.md)
+- [Runbooks verteilen](./runbooks.md)
+- [WGX-Doku-Stubs](./wgx-stub.md)
+- [Troubleshooting](./troubleshooting.md)

--- a/docs/ci-reusables.md
+++ b/docs/ci-reusables.md
@@ -1,0 +1,47 @@
+# CI-Reusables aus dem metarepo
+
+Das metarepo stellt wiederverwendbare GitHub-Actions-Workflows bereit,
+die Sub-Repos direkt referenzieren. Sie bilden die Fleet-Standards ab und
+verweisen bei Bedarf auf die WGX-Engine im [WGX-Repository](https://github.com/alexdermohr/wgx).
+
+## Verfügbare Workflows (`templates/.github/workflows/`)
+- `wgx-guard.yml` – überprüft das Vorhandensein des WGX-Profils (`.wgx/profile.yml`).
+- `wgx-smoke.yml` – ruft den `reusable-ci`-Workflow mit Standard-Inputs auf (Lint ja, Tests nein).
+- `reusable-ci.yml` – generischer CI-Baustein mit optionalen Lint- und Test-Schritten (`just`).
+
+## Konsum in Sub-Repos
+```yaml
+# .github/workflows/wgx-guard.yml im Ziel-Repo
+name: WGX Guard
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  guard:
+    uses: alexdermohr/metarepo/.github/workflows/wgx-guard.yml@main
+```
+
+Zusätzliche Beispiel-Einbindung für den Smoke-Workflow:
+
+```yaml
+jobs:
+  smoke:
+    uses: alexdermohr/metarepo/.github/workflows/wgx-smoke.yml@main
+    with:
+      run_tests: true
+```
+- Verwende immer einen **festen Ref**. Für reproduzierbare Builds **Tag oder Commit-SHA** pinnen.
+  - Beispiel Tag: `@metarepo-ci-v20251005`
+  - Beispiel Commit: `@d34db33f5e7c0de...`
+- `reusable-ci.yml` akzeptiert `run_lint`/`run_tests` (Booleans). Weitere Inputs bei Bedarf ergänzen.
+
+## Versionierung & Pinning
+- `main` spiegelt den aktuellen Fleet-Kanon.
+- Für reproduzierbare Pipelines Tags nutzen (`git tag metarepo-ci-vYYYYMMDD`), dann `@metarepo-ci-vYYYYMMDD` referenzieren.
+- Funktionale Änderungen (z. B. echte WGX-Checks) entstehen im WGX-Repo und werden hier nur verlinkt.
+
+## Caching-Hinweise
+- Lint/Test-Schritte basieren auf `just`. Stelle sicher, dass das Ziel-Repo entsprechende Rezepte anbietet.
+- Weitere Tools (z. B. `wgx`, `uv`, `lychee`) werden bei Bedarf projektindividuell installiert; dokumentiere Anpassungen im PR.

--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -1,0 +1,33 @@
+# Fleet-Operations im metarepo
+
+Das **metarepo** ist die Flotten-Leitstelle für alle Repositories unter `alexdermohr`.
+Es hält das Inventar (`repos.yml`), verteilt Templates/CI-Reusables und stößt WGX-Läufe an.
+Die kanonische WGX-Dokumentation bleibt im [WGX-Repository](https://github.com/alexdermohr/wgx).
+
+## Verantwortungsabgrenzung
+- **metarepo**
+  - Kuratiert Fleet-Scope und Standard-Templates (`templates/**`).
+  - Pflegt wiederverwendbare Workflows und Runbooks.
+  - Initiiert Fleet-Zyklen über `just` oder `scripts/wgx`.
+- **WGX-Repo**
+  - Enthält Master-Doku, Policies und Guard-Implementierung.
+  - Liefert die ausführbare Engine; metarepo ruft sie nur auf.
+
+## Fleet-Zyklus (sync → validate → smoke)
+1. **sync** – `just up` oder `./scripts/wgx up`
+   - Spiegelt die Templates/Runbooks in jedes Ziel-Repo.
+   - Nutzt `templates/**` als Quelle der Wahrheit.
+2. **validate** – `just validate` oder `./scripts/wgx validate`
+   - Prüft `repos.yml` auf Schemafehler und verifiziert, dass Pflicht-Templates vorhanden sind.
+   - Optional ergänzen durch `./scripts/wgx-doctor` für Drift-Analysen.
+3. **smoke** – `just smoke` oder `./scripts/wgx smoke`
+   - Triggert die WGX-Smoke-Workflows in jedem Repo (`wgx-smoke.yml`).
+   - Ergebnis dient als Fleet-Gesundheitsindikator.
+
+> 💡 Detailwissen zu WGX-Kommandos, Guards oder Profilen wird **nicht** im metarepo verdoppelt.
+> Link stattdessen direkt auf die Master-Doku im WGX-Repo.
+
+## Betriebsnotizen
+- `reports/` sammelt Ausgaben von Drift-/Doctor-Läufen.
+- Fleet-Änderungen immer mit kurzem Incident-Log in PR-Beschreibung dokumentieren.
+- Für Ad-hoc-Syncs einzelner Repos `scripts/sync-templates.sh --push-to <repo> --pattern "templates/**"` nutzen.

--- a/docs/repos.yml.md
+++ b/docs/repos.yml.md
@@ -1,0 +1,41 @@
+# `repos.yml` – Inventar & Filter
+
+`repos.yml` definiert, welche Repositories vom metarepo als Teil der Fleet behandelt werden.
+Das File wird von `scripts/wgx` und `scripts/sync-templates.sh --repos-from` gelesen.
+
+## Schema
+```yaml
+# Modus: "static" (nur Liste) oder "github" (per GitHub-API ermitteln)
+mode: static
+
+# GitHub-Owner/Organisation der Fleet
+github:
+  owner: alexdermohr
+
+# Statische Fleet-Liste (genutzt, wenn mode: static)
+repos:
+  - weltgewebe
+  - hauski-audio
+
+static:
+  include:
+    - semantAH
+    - wgx
+```
+
+### Felder
+- `mode`
+  - `static` (Default): Fleet-Liste kommt aus `repos` + `static.include`.
+  - `github`: Fleet wird dynamisch über `gh repo list <owner>` bestimmt.
+- `github.owner`: GitHub Namespace. Wird auch von `scripts/sync-templates.sh --owner-from-env` genutzt.
+- `repos`: Kernmenge der Repositories. Kommentare (`# ...`) werden ignoriert.
+- `static.include`: Ergänzende Repos, z. B. wenn `repos` leer bleiben soll.
+
+## Standard-Policy
+- Fleet umfasst alle **öffentlichen** Repos unter `alexdermohr`.
+- Ausnahme: `vault-gewebe` bleibt aus Datenschutzgründen ausgeschlossen.
+
+## Praxis-Tipps
+- Für einmalige Pushes `scripts/sync-templates.sh --repos-from repos.yml --pattern "templates/.github/workflows/*.yml"`.
+- Bei `mode: github` regelmäßig `gh auth status` prüfen (Token für `gh repo list`).
+- Änderungen an `repos.yml` immer mit PR begründen (z. B. neues Repo aufgenommen / stillgelegt).

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1,0 +1,32 @@
+# Runbooks in der Fleet verteilen
+
+Runbooks sind klickbare Markdown-Anleitungen, die in den Sub-Repos landen sollen.
+Sie liegen im metarepo unter `templates/docs/runbooks/` (lege bei Bedarf neue Dateien dort an).
+
+## Lifecycle
+1. **Authoring im metarepo** – neue Runbooks als Markdown schreiben.
+2. **Sync** – `just up` oder `scripts/sync-templates.sh --pattern "templates/docs/runbooks/*.md"`.
+3. **Review** – In der Sync-PR verlinken, wie der Runbook-Eintrag im Ziel-Repo benutzt wird (z. B. README-Abschnitt, Issue-Vorlage).
+
+## Gestaltung
+- Dateiname im Format `NNN-name.md` für sortierbare Listen (z. B. `010-oncall-start.md`).
+- Erster Absatz: Zweck + Zielgruppe.
+- Verwende Callouts (`> ℹ️`) für Hinweise, Checklisten als Checkboxen (`- [ ]`).
+
+## Ausführung über WGX
+- WGX kann Runbooks als Task referenzieren (`wgx run runbooks/<name>`), sobald ein entsprechendes Profil existiert.
+- Wenn ein Runbook einen Befehl benötigt, pflege den Command in `.wgx/profile.yml` und verlinke ihn aus dem Markdown.
+
+## Ownership
+- Jede Runbook-Datei **muss** einen Owner im Frontmatter tragen, z. B.:
+  ```yaml
+  ---
+  title: Oncall Start
+  owner: fleet-team
+  severity: info
+  ---
+  ```
+- Änderungen immer mit dem Owner abstimmen und im PR erwähnen.
+
+> 💡 Runbooks sind **Stubs**: Sie erklären das „Wie“ für die Fleet.
+> Tool-spezifische Details (z. B. WGX-Subcommands) werden in der WGX-Doku gepflegt.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,29 @@
+# Templates verteilen & driftfrei halten
+
+Alle Fleet-Vorlagen leben unter `templates/**`. Sie werden 1:1 in Sub-Repos gespiegelt
+(`scripts/wgx up` oder `scripts/sync-templates.sh`).
+
+## Ordnerstruktur
+- `templates/.github/workflows/` – Reusable- und Fleet-Workflows (`wgx-guard`, `wgx-smoke`, `reusable-ci`).
+- `templates/.wgx/profile.yml` – Standardprofil für WGX.
+- `templates/docs/**` – Referenzdokumente (z. B. `wgx-konzept.md`, ADR-Template).
+- `templates/Justfile` – Fleet-Justfile mit `just up|validate|smoke`.
+
+## Sync-Strategien
+- **Voll-Sync**: `just up` bzw. `./scripts/wgx up` kopiert sämtliche Templates in jedes Repo.
+- **Selektiv**: `scripts/sync-templates.sh --push-to <repo> --pattern "templates/.github/workflows/*.yml"`.
+- **Pull-Lernen**: `scripts/sync-templates.sh --pull-from <repo> --pattern "templates/docs/**"` holt Verbesserungen zurück ins metarepo.
+
+Setze immer `--dry-run`, wenn du neue Muster ausprobierst.
+
+## Drift-Kontrolle
+1. `./scripts/wgx-doctor --repo <repo>` erzeugt einen Drift-Report in `reports/`.
+2. Prüfe Differenzen; entscheide, ob lokale Änderungen kuratiert (→ Pull) oder überschrieben (→ Push) werden.
+3. Dokumentiere das Ergebnis im PR (Wer gewinnt? Warum?).
+
+## Konflikte lösen
+- Konflikte entstehen, wenn Sub-Repos die Templates anpassen.
+- Nutze Pull-Lernen, um Verbesserungen zurückzuholen.
+- Bei harten Abweichungen neue Fleet-Regel definieren (z. B. repo-spezifische Ausnahme im Ziel-Repo dokumentieren).
+
+> 🔗 Deep-Dive zu WGX-spezifischen Settings siehe [WGX-Doku](https://github.com/alexdermohr/wgx).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,49 @@
+# Troubleshooting (Top-Fleet-Issues)
+
+Kurzer Spickzettel für die häufigsten Stolpersteine rund um Fleet-Sync & WGX.
+
+## 1. `wgx` nicht im PATH
+- Symptom: CI-Job bricht mit `command not found: wgx` ab.
+- Fix: Installationsschritte aus der [WGX-Doku](https://github.com/alexdermohr/wgx) in den Workflow einbauen (z. B. Setup-Script
+  vor den Guard-Checks ausführen).
+
+## 2. CI ohne `uv`
+- Symptom: Python-Projekte laufen in der CI ohne Abhängigkeits-Cache.
+- Fix: Vor dem `just`-Aufruf `pipx install uv` (oder entsprechendes Setup) ausführen und den Cache-Pfad als `actions/cache`
+  Schritt hinterlegen.
+
+## 3. `lychee` / `cspell` langsam
+- Symptom: PR-Checks dauern >10 Minuten.
+- Fix: Link-/Spell-Checks in separate Workflows auslagern oder via Workflow-Inputs deaktivierbar machen; Ergebnisse in Nightly
+  Pipelines konsolidieren.
+
+## 4. Template-Drift nach lokalem Hotfix
+- Symptom: Sub-Repo hat Änderungen, die beim nächsten Sync überschrieben würden.
+- Fix: `scripts/sync-templates.sh --pull-from <repo> --pattern "templates/**"` nutzen, Änderung im metarepo kuratieren.
+
+## 5. `gh` Rate-Limits
+- Symptom: `scripts/wgx list` scheitert mit API-Errors.
+- Fix: `gh auth login` mit PAT, `GH_TOKEN` als Secret im CI setzen.
+
+## 6. Merge-Konflikt beim Stub-Dokument
+- Symptom: `docs/wgx-konzept.md` wird lokal erweitert.
+- Fix: Hinweis auf Stub-Policy geben, Ergänzungen in WGX-Repo verlagern.
+
+## 7. Reports fehlen
+- Symptom: `reports/` bleibt leer trotz Doctor-Lauf.
+- Fix: Prüfe, ob `./scripts/wgx-doctor --repo <name>` erfolgreich durchlief (kein Clone-Error) und ob Unterschiede existierten.
+  Ohne Drift wird kein Abschnitt erzeugt – dennoch entsteht eine leere Report-Datei. CI-Artefakte gezielt einsammeln.
+
+## 8. `scripts/sync-templates.sh` meldet „Keine Repos in Datei“
+- Symptom: `--repos-from` liefert keine Ziele.
+- Fix: In `repos.yml` müssen `repos:` **oder** `static.include:` gefüllt sein (Kommentare zählen nicht).
+
+## 9. SSH statt HTTPS erwartet
+- Symptom: `scripts/wgx up` schlägt beim Klonen fehl.
+- Fix: Stelle `git@github.com:...` Zugriff sicher (SSH-Key), oder passe Workflow auf HTTPS an (`GH_TOKEN`).
+
+## 10. Fehlende Owner-Angabe
+- Symptom: `scripts/wgx` gibt `owner=` leer aus.
+- Fix: `github.owner` in `repos.yml` setzen oder `GITHUB_OWNER` exportieren.
+
+Weitere Issues? → GitHub Issue im metarepo öffnen und in der nächsten Fleet-Runde dokumentieren.

--- a/docs/wgx-stub.md
+++ b/docs/wgx-stub.md
@@ -1,0 +1,24 @@
+# WGX-Doku-Stubs im metarepo
+
+Das metarepo liefert nur **Verweise** auf die kanonische WGX-Dokumentation.
+Alle inhaltlichen Details (Policies, CLI-Referenz, Troubleshooting) liegen im
+[WGX-Repository](https://github.com/alexdermohr/wgx).
+
+## Zweck des Stubs
+- Einheitliche Platzhalter-Datei (`docs/wgx-konzept.md`) in allen Sub-Repos.
+- Verlinkt auf die Master-Doku und erklärt kurz den lokalen Bezug (Profil, Runbooks).
+- Verhindert Dokument-Drift zwischen Fleet und Engine.
+
+## Einbindung in Sub-Repos
+Die Datei `templates/docs/wgx-konzept.md` wird bei jedem Sync verteilt.
+Sub-Repos sollen sie **nicht** eigenständig erweitern, sondern auf neue Inhalte im WGX-Repo verweisen.
+
+```markdown
+# WGX – Einstieg
+Mehr dazu: https://github.com/alexdermohr/wgx
+```
+
+## Änderungen am Stub
+- Anpassungen nur hier im metarepo vornehmen.
+- Wenn tiefergehende Doku nötig ist, Issue/PR im WGX-Repo eröffnen.
+- Kurze Changelog-Notiz in der Sync-PR hinterlassen (z. B. „WGX-Stub Link auf neues Kapitel aktualisiert“).

--- a/templates/.github/workflows/.keep
+++ b/templates/.github/workflows/.keep
@@ -1,0 +1,1 @@
+# Placeholder to keep the workflow templates directory tracked.

--- a/templates/docs/runbooks/.keep
+++ b/templates/docs/runbooks/.keep
@@ -1,0 +1,1 @@
+# Platzhalter, damit templates/docs/runbooks/ eingecheckt bleibt

--- a/templates/docs/wgx-konzept.md
+++ b/templates/docs/wgx-konzept.md
@@ -1,2 +1,2 @@
-# WGX – Dünner Meta-Layer
-Ziel: Kanon der Projekt-Templates, einheitliche Kommandos (`wgx up|list|run|doctor|validate|smoke`), Priorität Envs: Devcontainer → Devbox → mise/direnv → Termux.
+# WGX – Einstieg
+Mehr dazu: https://github.com/alexdermohr/wgx


### PR DESCRIPTION
## Summary
- add a scheduled docs link-check workflow so tower docs stay fresh
- update the distributed WGX concept stub to just point at the canonical repository
- keep the workflow template path tracked with a documented placeholder file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e20d2d2a1c832cbdae1515745facd8