### PR TITLE
Fix docs link check workflow

### DIFF
--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up lychee
-        uses: lycheeverse/lychee-action@v1
       - name: Check documentation links
-        run: lychee --no-progress --exclude-mail --timeout 10s docs/**/*.md
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --no-progress --exclude-mail --timeout 10s docs/**/*.md


### PR DESCRIPTION
## Summary
- adjust docs link checker workflow to run lychee via the official action
- ensure the scheduled job actually executes the link scan instead of failing to find the CLI

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2184de824832ca24876da079b4b1a