### PR TITLE
Introduce ADR framework & core decisions (000–005)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# CODEOWNERS for architecture decision records
+/docs/adr/** @alexdermohr

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## ADR-Änderungen
+- [ ] Neue ADR(s): Nummer & Titel:
+- [ ] Status korrekt (Proposed/Accepted/Superseded)
+- [ ] Betroffene Tower-Dokumente verlinkt (fleet/templates/ci/…)
+- [ ] Konsequenzen klar beschrieben
+
+## Kontext & Motivation
+(1–3 Sätze)
+
+## Review-Notizen
+(Was soll besonders beachtet werden?)

--- a/.github/workflows/adr-lint.yml
+++ b/.github/workflows/adr-lint.yml
@@ -1,0 +1,32 @@
+name: adr-lint
+on:
+  pull_request:
+    paths: ['docs/adr/**']
+  workflow_dispatch:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check filenames & headers
+        run: |
+          fail=0
+          for f in docs/adr/*.md; do
+            bn=$(basename "$f")
+            [[ "$bn" =~ ^[0-9]{3}-.*\.md$ ]] || { echo "::error ::Invalid ADR filename: $bn"; fail=1; }
+            head -n 1 "$f" | grep -q "^# ADR-" || { echo "::error ::Missing H1 ADR header in $bn"; fail=1; }
+          done
+          exit $fail
+      - name: Stale proposed ADRs (>7d)
+        run: |
+          set -e
+          while IFS= read -r -d '' f; do
+            stat=$(grep -m1 '^Status:' "$f" | awk '{print tolower($2)}')
+            date=$(grep -m1 '^Datum:' "$f" | awk '{print $2}')
+            if [ "$stat" = "proposed" ] && [ -n "$date" ]; then
+              days=$(( ( $(date +%s) - $(date -d "$date" +%s) ) / 86400 ))
+              if [ $days -gt 7 ]; then
+                echo "::warning ::ADR $(basename "$f") is Proposed for $days days"
+              fi
+            fi
+          done < <(find docs/adr -maxdepth 1 -name '*.md' -print0)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@ Für **WGX (Engine)** siehe: https://github.com/alexdermohr/wgx
 - [Runbooks verteilen](./runbooks.md)
 - [WGX-Doku-Stubs](./wgx-stub.md)
 - [Troubleshooting](./troubleshooting.md)
+- [Architecture Decision Records (ADRs)](./adr/README.md)

--- a/docs/adr/000-adr-governance.md
+++ b/docs/adr/000-adr-governance.md
@@ -1,0 +1,16 @@
+# ADR-000: ADR-Governance & Format  
+![status: proposed](https://img.shields.io/badge/status-proposed-yellow)
+Datum: 2025-10-05
+Status: Proposed
+Owner: fleet-team
+## Kontext
+Metarepo dient als Tower; zentrale Policies sollen nachvollziehbar versioniert sein.
+## Entscheidung
+- Nummerierung fortlaufend, `docs/adr/NNN-title.md`.
+- Status: Proposed → Accepted → Superseded.
+- Review-Fenster: 72h, mind. 1 Approver außerhalb des Autors.
+## Konsequenzen
+Nachvollziehbarkeit, klarer Änderungsverlauf.
+## Alternativen
+Nur Issues/PRs (zu flüchtig), Wiki (Drift).
+## Links

--- a/docs/adr/000-template.md
+++ b/docs/adr/000-template.md
@@ -1,0 +1,10 @@
+# ADR-<NUMMER>: <TITEL>  
+![status: proposed](https://img.shields.io/badge/status-proposed-yellow)
+Datum: <YYYY-MM-DD>
+Status: Proposed
+Owner: <name>
+## Kontext
+## Entscheidung
+## Konsequenzen
+## Alternativen
+## Links

--- a/docs/adr/001-engine-vs-tower.md
+++ b/docs/adr/001-engine-vs-tower.md
@@ -1,0 +1,16 @@
+# ADR-001: WGX (Engine) vs. metarepo (Tower)  
+![status: proposed](https://img.shields.io/badge/status-proposed-yellow)
+Datum: 2025-10-05
+Status: Proposed
+Owner: fleet-team
+## Kontext
+WGX liefert Bedienkanon, Guard/Smoke, Policies; metarepo verteilt und beobachtet.
+## Entscheidung
+- WGX-Doku bleibt ausschließlich im WGX-Repo; metarepo liefert nur Stubs/Links.
+- Metarepo verteilt Templates/CI-Reusables und ruft WGX auf; keine eigene Guard/Smoke-Logik.
+## Konsequenzen
+Kein Dokument-Drift, eine Quelle der Wahrheit, klarer Update-Pfad.
+## Alternativen
+Doppelte Doku/Checks im Tower (führt zu Drift).
+## Links
+- docs/fleet.md, docs/ci-reusables.md, docs/wgx-stub.md

--- a/docs/adr/002-distribution-drift.md
+++ b/docs/adr/002-distribution-drift.md
@@ -1,0 +1,16 @@
+# ADR-002: Fleet-Distribution & Drift-Regeln  
+![status: proposed](https://img.shields.io/badge/status-proposed-yellow)
+Datum: 2025-10-05
+Status: Proposed
+Owner: fleet-team
+## Kontext
+Templates unter `templates/**` werden in Sub-Repos gespiegelt.
+## Entscheidung
+- Pull-Lernen bevorzugen; nur bei Konflikt Push-Kanon.
+- Drift-Reports unter `reports/` je Lauf; PR-Notizen verpflichtend.
+## Konsequenzen
+Kuratierte Verbesserungen, weniger heimliche Abweichungen.
+## Alternativen
+Hartes Überschreiben (verliert lokale Verbesserungen).
+## Links
+- docs/templates.md, docs/fleet.md

--- a/docs/adr/003-ci-reusables-pinning.md
+++ b/docs/adr/003-ci-reusables-pinning.md
@@ -1,0 +1,16 @@
+# ADR-003: CI-Reusables & Pinning-Policy  
+![status: proposed](https://img.shields.io/badge/status-proposed-yellow)
+Datum: 2025-10-05
+Status: Proposed
+Owner: ci-team
+## Kontext
+Sub-Repos referenzieren metarepo-Workflows.
+## Entscheidung
+- Referenzierung mit Tag oder Commit-SHA (kein floating außer bewusst `@main`).
+- Funktionale Engine-Checks liegen in WGX; Tower-Workflows rufen WGX auf.
+## Konsequenzen
+Reproduzierbare Pipelines, klare Verantwortlichkeit.
+## Alternativen
+Inline-Workflows in jedem Repo (Pflegeaufwand).
+## Links
+- docs/ci-reusables.md

--- a/docs/adr/004-wgx-profile-v1.md
+++ b/docs/adr/004-wgx-profile-v1.md
@@ -1,0 +1,12 @@
+# ADR-004: `.wgx/profile.yml v1` – Minimal-Schema  
+![status: proposed](https://img.shields.io/badge/status-proposed-yellow)
+Datum: 2025-10-05
+Status: Proposed
+Owner: wgx-core
+## Entscheidung
+Pflichtfelder: topTasks[], env.prefer[], contracts{}, alias{}, smoke.profile, ci.template.
+Evolutionsplan v1.1: ranges für requiredWgx, envDefaults/Overrides.
+## Konsequenzen
+Deterministischer Runner/Guard/Smoke über Repos.
+## Links
+- docs/wgx-stub.md

--- a/docs/adr/005-evidence-linkhealth.md
+++ b/docs/adr/005-evidence-linkhealth.md
@@ -1,0 +1,12 @@
+# ADR-005: Evidence-Packs (light) & zentraler Link-Health  
+![status: proposed](https://img.shields.io/badge/status-proposed-yellow)
+Datum: 2025-10-05
+Status: Proposed
+Owner: ci-team
+## Entscheidung
+- Evidence-Packs bündeln guard/smoke-Summaries + tool-versions (timecapsule-light).
+- Link-Check (lychee) läuft zentral im metarepo (Nightly), nicht in allen Repos.
+## Konsequenzen
+Nachvollziehbare PRs, weniger Lint-Lärm in Sub-Repos.
+## Links
+- docs/ci-reusables.md

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records (ADRs)
+Dieses Verzeichnis enthält entscheidende Architektur-/Policy-Beschlüsse.
+
+**Workflow:** Proposed → Accepted → Superseded  
+**Owner:** siehe [CODEOWNERS](/.github/CODEOWNERS)
+
+## Aktuelle ADRs
+- [000 – ADR-Governance & Format](./000-adr-governance.md) — **Proposed**
+- [001 – WGX (Engine) vs. metarepo (Tower)](./001-engine-vs-tower.md) — **Proposed**
+- [002 – Fleet-Distribution & Drift-Regeln](./002-distribution-drift.md) — **Proposed**
+- [003 – CI-Reusables & Pinning-Policy](./003-ci-reusables-pinning.md) — **Proposed**
+- [004 – .wgx/profile.yml v1 – Minimal-Schema](./004-wgx-profile-v1.md) — **Proposed**
+- [005 – Evidence-Packs & Link-Health](./005-evidence-linkhealth.md) — **Proposed**
+
+> **Hinweis:** „Accepted“-ADRs sollten zeitnah in den Tower-Docs gespiegelt werden (Links/Reads).


### PR DESCRIPTION
## Summary
- add an ADR template and CODEOWNERS entry for tower decision records
- document governance, engine/tower split, distribution rules, CI pinning, profile schema, and evidence policy in ADR-000 to ADR-005
- link the ADR collection from the docs index for discoverability
- add an ADR index README, status badges, a PR template, and an adr-lint workflow to enforce naming and highlight stale proposed decisions

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e219167acc832c995b76a769a683b9