### PR TITLE
docs: automate sync log drafts

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,9 @@ smoke:
 sync:
     scripts/sync-templates.sh
 
+log-sync *args:
+    scripts/create-sync-log.py {{args}}
+
 # Local CI
 ci:
     bash .github/workflows/validate-local.sh 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ Enthält:
 Siehe `repos.yml`. Standard: alle öffentlichen Repos unter `alexdermohr`, **außer** `vault-gewebe` (privat).
 
 ## Quickstart
-1. `just list` – Repos anzeigen  
-2. `just up` – Templates in alle Repos spiegeln  
-3. `just smoke` – Fleet-Healthcheck (read-only Checks)  
+1. `just list` – Repos anzeigen
+2. `just up` – Templates in alle Repos spiegeln
+3. `just smoke` – Fleet-Healthcheck (read-only Checks)
 4. `just validate` – prüft Template-Konsistenz
+
+### Sync-Run-Logs pflegen
+- `just log-sync` – legt auf Basis von `reports/sync-logs/_TEMPLATE.sync-run.md` einen neuen Report mit aktuellem Datum an. Optional: zusätzliche Flags (z. B. `--repo-scope "repos.yml (static)"`).
+- Reports landen in [`reports/sync-logs/`](reports/sync-logs/) und dokumentieren Blocker & Folgemaßnahmen rund um Flottenläufe.
 
 > Für Dummies: Dieses Repo ist die Schaltzentrale. Hier pflegst du Regeln und Vorlagen **einmal** und verteilst sie dann in alle anderen Repos. So vermeidest du Doppelpflege und Chaos.
 

--- a/reports/.gitattributes
+++ b/reports/.gitattributes
@@ -1,0 +1,1 @@
+*.md text eol=lf

--- a/reports/.gitignore
+++ b/reports/.gitignore
@@ -1,2 +1,5 @@
 *.md
-!/.gitkeep
+!.gitkeep
+!sync-logs/
+!sync-logs/*.md
+!sync-logs/.gitkeep

--- a/reports/sync-logs/2024-05-17-sync-run.md
+++ b/reports/sync-logs/2024-05-17-sync-run.md
@@ -1,0 +1,25 @@
+# Sync Attempt Log — 2024-05-17
+
+## Context
+- Operator: Codex agent @ container `901720d8dcec`
+- Repo scope: `repos.yml` (static include: weltgewebe, hauski-audio, semantah, wgx, hauski)
+- Branch context: `work`
+- Git: git version 2.43.0 | rsync: rsync  version 3.2.7  protocol version 31 | gh: n/a (not installed)
+- Network: Outbound HTTPS blocked by upstream proxy (APT + GitHub fetch → 403 Forbidden)
+- Proxy configured: none (system lacks credentials)
+
+## Steps
+1. Prereq check: **failed partially** — `gh` CLI missing; attempted `apt-get install gh` aborted because proxy returned `403 Forbidden`. Confirmed `rsync` available and `git` v2.43.0 present.
+2. Fleet listing: **succeeded via fallback** — parsed `repos.yml` directly to enumerate weltgewebe, hauski-audio, semantah, wgx, hauski.
+3. Template validation: **succeeded** — fallback checks verified presence of `.wgx/profile.yml`, `reusable-ci`, and `wgx-guard` templates.
+4. Sync dry-run: **failed** — `./scripts/sync-templates.sh --repos-from repos.yml --dry-run` aborted on first clone because HTTPS access to GitHub was denied (proxy credentials missing).
+
+## Blockers
+- `gh` executable absent, preventing workflow triggers or branch protection adjustments.
+- HTTPS egress restricted: both APT and `git clone` operations receive proxy-mediated `403 Forbidden` responses.
+
+## Suggested Next Steps
+- Restore outbound HTTPS connectivity or provide proxy credentials for APT and GitHub.
+- Install the GitHub CLI (`gh`) and authenticate before retrying fleet tasks.
+- Re-run the sync script (optionally with `--dry-run`) once network access is functional.
+- Consider bundling `gh` binaries and mirrored repositories inside the devcontainer to remove external dependencies during maintenance runs.

--- a/reports/sync-logs/_TEMPLATE.sync-run.md
+++ b/reports/sync-logs/_TEMPLATE.sync-run.md
@@ -1,0 +1,21 @@
+# Sync Attempt Log — {{DATE_ISO}}
+
+## Context
+- Operator: {{USER}} @ {{HOST}}
+- Repo scope: {{REPO_SCOPE}}
+- Branch context: {{BRANCH_CONTEXT}}
+- Git: {{GIT_VERSION}} | rsync: {{RSYNC_VERSION}} | gh: {{GH_VERSION}}
+- Network: {{NETWORK_DESC}}
+- Proxy configured: {{PROXY_SET}}
+
+## Steps
+1. Prereq check: {{PREREQ_STATUS}} — notes: {{PREREQ_NOTES}}
+2. Fleet listing: {{FLEET_STATUS}} — repos: {{REPOS_LIST}}
+3. Template validation: {{VALIDATION_STATUS}} — missing: {{MISSING_ITEMS}}
+4. Sync: mode={{DRY_RUN}} — result: {{SYNC_RESULT}} (exit={{EXIT_CODE}})
+
+## Blockers
+- {{BLOCKERS}}
+
+## Next Actions
+- {{FOLLOW_UP}}

--- a/scripts/create-sync-log.py
+++ b/scripts/create-sync-log.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import getpass
+import socket
+import subprocess
+from pathlib import Path
+
+TEMPLATE_PATH = Path("reports/sync-logs/_TEMPLATE.sync-run.md")
+OUTPUT_DIR = Path("reports/sync-logs")
+
+
+def run_cmd(*args: str) -> str:
+    try:
+        completed = subprocess.run(args, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    except FileNotFoundError:
+        return "n/a"
+    except subprocess.CalledProcessError:
+        return "n/a"
+    line = completed.stdout.strip().splitlines()
+    return line[0] if line else "n/a"
+
+
+def detect_branch() -> str:
+    try:
+        completed = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    except subprocess.CalledProcessError:
+        return "unknown"
+    branch = completed.stdout.strip()
+    return branch or "unknown"
+
+
+def build_replacements(args: argparse.Namespace) -> dict[str, str]:
+    date_iso = args.date or dt.date.today().isoformat()
+    repo_scope = args.repo_scope or "repos.yml"
+    replacements: dict[str, str] = {
+        "DATE_ISO": date_iso,
+        "USER": getpass.getuser(),
+        "HOST": socket.gethostname(),
+        "REPO_SCOPE": repo_scope,
+        "BRANCH_CONTEXT": detect_branch(),
+        "GIT_VERSION": run_cmd("git", "--version"),
+        "RSYNC_VERSION": run_cmd("rsync", "--version"),
+        "GH_VERSION": run_cmd("gh", "--version"),
+        "NETWORK_DESC": "unknown — fill in",
+        "PROXY_SET": "unknown",
+        "PREREQ_STATUS": "TBD",
+        "PREREQ_NOTES": "TBD",
+        "FLEET_STATUS": "TBD",
+        "REPOS_LIST": "TBD",
+        "VALIDATION_STATUS": "TBD",
+        "MISSING_ITEMS": "TBD",
+        "DRY_RUN": "TBD",
+        "SYNC_RESULT": "TBD",
+        "EXIT_CODE": "TBD",
+        "BLOCKERS": "TBD",
+        "FOLLOW_UP": "TBD",
+    }
+    return replacements
+
+
+def render_template(template: Path, replacements: dict[str, str]) -> str:
+    content = template.read_text(encoding="utf-8")
+    for key, value in replacements.items():
+        placeholder = f"{{{{{key}}}}}"
+        content = content.replace(placeholder, value)
+    return content
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Instantiate a sync attempt log from the shared template.")
+    parser.add_argument("--date", help="ISO date for the log filename and placeholder (default: today)")
+    parser.add_argument("--repo-scope", help="Description of the repo selection recorded in the log")
+    parser.add_argument("--output", help="Custom output path for the log (default: reports/sync-logs/<date>-sync-run.md)")
+    parser.add_argument("--template", default=str(TEMPLATE_PATH), help="Path to the template file")
+    parser.add_argument("--force", action="store_true", help="Overwrite the output file if it already exists")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    template_path = Path(args.template)
+    if not template_path.exists():
+        raise SystemExit(f"Template not found: {template_path}")
+
+    replacements = build_replacements(args)
+    content = render_template(template_path, replacements)
+
+    date_iso = replacements["DATE_ISO"]
+    default_output = OUTPUT_DIR / f"{date_iso}-sync-run.md"
+    output_path = Path(args.output) if args.output else default_output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if output_path.exists() and not args.force:
+        raise SystemExit(f"Refusing to overwrite existing log: {output_path}")
+
+    output_path.write_text(content, encoding="utf-8")
+    print(f"Created sync log draft: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a helper script and `just log-sync` target to generate sync attempt log drafts from the shared template
- refresh the sync template and the 2024-05-17 incident log so repo/branch context and blockers are captured consistently
- document the logging workflow in the README and enforce LF endings for report markdown files

## Testing
- scripts/create-sync-log.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e24323ac3c832c909b5399ae63647a