### PR TITLE
fix(validate-templates): restrict yaml lint to tracked files

### DIFF
--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check YAMLs
         run: |
           pipx install yq || true
-          find . -type f -name '*.yml' -o -name '*.yaml' | xargs -r -I{} python -c "import yaml,sys; yaml.safe_load(open('{}'))"
+          git ls-files -z -- '*.yml' '*.yaml' | xargs -0 -r -I{} python -c "import yaml,sys; yaml.safe_load(open('{}'))"
       - name: List templates
         run: |
           find templates -type f | sort


### PR DESCRIPTION
## Summary
- limit the YAML validation step to tracked files so that `.git` log entries are ignored

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e29a67960c832c9f987e24f7feb2cc