### PR TITLE
Fix ShellCheck prefix trimming in sync script

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -77,6 +77,7 @@ copy_into_metarepo_from_repo(){
   local name="$1"
   local src=""
   local -a files=()
+  local prefix=""
   for p in "${PATTERNS[@]}"; do
     case "$p" in
       templates/*) src="${p#templates/}" ;;
@@ -93,9 +94,10 @@ copy_into_metarepo_from_repo(){
     fi
     mapfile -t files < <(compgen -G -- "$TMPDIR/$name/$src" 2>/dev/null || true)
 
+    prefix="${TMPDIR}/${name}/"
     for f in "${files[@]}"; do
       # Remove TMPDIR/$name/ prefix for destination path
-      rel_f="${f#${TMPDIR}/${name}/}"
+      rel_f="${f#${prefix}}"
       [[ -z "$rel_f" || "$rel_f" == "$f" ]] && continue
       dest="$PWD/templates/$rel_f"
       if ((DRYRUN==1)); then


### PR DESCRIPTION
## Summary
- ensure the temporary directory prefix is trimmed without quoted expansions to satisfy ShellCheck
- reuse a local prefix variable inside copy_into_metarepo_from_repo for clarity

## Testing
- bash -n scripts/sync-templates.sh

------
https://chatgpt.com/codex/tasks/task_e_68e29a64ecac832c8942a97bcdd86a55