### PR TITLE
fix: ensure sync templates shebang first

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -1,4 +1,3 @@
-# c2b: scripts/sync-templates.sh (ideal)
 #!/usr/bin/env bash
 # c2b: scripts/sync-templates.sh (ideal)
 set -euo pipefail


### PR DESCRIPTION
## Summary
- ensure the sync-templates script begins with the shebang by moving the c2b comment below it

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e2a0593ab8832ca4f8e7b9b0be0bb0