### PR TITLE
docs: note tool bootstrap attempt for 2025-10-05 sync log

### DIFF
--- a/reports/sync-logs/2025-10-05-sync-run.md
+++ b/reports/sync-logs/2025-10-05-sync-run.md
@@ -1,0 +1,33 @@
+# Sync Attempt Log — 2025-10-05
+
+## Context
+- Operator: root @ 977fcbff9e0b
+- Repo scope: repos.yml (static)
+- Branch context: work
+- Git: git version 2.43.0 | rsync: rsync  version 3.2.7  protocol version 31 | gh: n/a
+- Network: Restricted egress — outbound HTTP(S) requests to apt/github return 403
+- Proxy configured: none detected
+
+## Steps
+1. Prereq check: failed — notes: `just doctor` unavailable (just missing) and `scripts/wgx doctor` exits with `Fehlt: yq`; dependency installation blocked by 403
+2. Fleet listing: blocked — repos: n/a (requires `yq` to parse repos.yml)
+3. Template validation: not run — missing: yq / gh CLI
+4. Sync: mode=not started — result: blocked (exit=dependency-missing)
+
+## Blockers
+- `yq` (mikefarah) binary not available and cannot be downloaded due to 403 restrictions; GH CLI (`gh`) also absent
+
+## Next Actions
+- Re-run in environment with `just`, `yq` v4, and `gh` available (or installable) to allow WGX workflows to execute
+
+## Re-Run — 2025-10-05 (Tool Bootstrap Attempt)
+- commit: c2fdc26
+- duration: n/a (blocked before sync)
+- exit_code: 127 (docker)
+- Tool container: `docker run ghcr.io/codex-bundles/wgx-fleet:stable` → `command not found: docker`
+- Host tools: yq: missing | gh: missing | just: missing
+- DRYRUN: not executed — `./scripts/wgx doctor` exits with `Fehlt: yq`
+- Real sync: not executed — `./scripts/wgx up` exits with `Fehlt: yq`
+- CI trigger: not executed — `./scripts/wgx run ci` exits with `Fehlt: yq`
+- Notes: Environment lacks Docker runtime and outbound HTTPS to fetch binaries; cannot provision yq/gh/just offline.
+- Next action: Retry from workstation/devcontainer that has Docker (or pre-baked toolchain) and unrestricted access to required binaries.


### PR DESCRIPTION
## Summary
- extend the 2025-10-05 sync attempt log with a re-run entry covering the tool bootstrap attempt
- record that docker is unavailable in the current environment and the wgx commands remain blocked by missing yq/gh/just

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2b0c330c8832cab4900934ac68a02